### PR TITLE
Add git clone to instructions and show how to pass options

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,20 @@ You need to have Docker installed on your machine. You can find instructions on 
 
 ## Usage
 
+First, clone the repository:
+
+```bash
+git clone https://github.com/rails/rails-new.git
+cd rails-new
+```
+
 To generate a new Rails application, you can run the following command:
 
 ```bash
 bin/rails-new myapp
+```
+
+Or with options:
+```bash
+bin/rails-new myapp --main
 ```


### PR DESCRIPTION
This adds more complete instructions for usage by adding the git clone step. Also adds an example of usage once #1 is merged to forward all arguments to `rails new`