### PR TITLE
feature: expose `--help` from rails

### DIFF
--- a/src/docker_client.rs
+++ b/src/docker_client.rs
@@ -50,4 +50,18 @@ impl DockerClient {
 
         command
     }
+
+    pub fn get_help(ruby_version: &str, rails_version: &str) -> Command {
+        let mut command = Command::new("docker");
+
+        command
+            .arg("run")
+            .arg("--rm")
+            .arg(format!("rails-new-{}-{}", ruby_version, rails_version))
+            .arg("rails")
+            .arg("new")
+            .arg("--help");
+
+        command
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@
 mod docker_client;
 mod rails_new;
 use rails_new::{Cli, Commands};
-use std::io::Write;
+use std::{io::Write, process::Command};
 
 use clap::Parser;
 
@@ -40,22 +40,20 @@ fn main() {
 
     assert!(status.success());
 
+    let mut command: Command;
+
     match &cli.command {
         Some(Commands::RailsHelp {}) => {
-            let status = DockerClient::get_help(&ruby_version, &rails_version)
-                .status()
-                .expect("Failed to execute process");
-
-            assert!(status.success());
+            command = DockerClient::get_help(&ruby_version, &rails_version)
         }
 
         None => {
             // Run the image with docker run -v $(pwd):/$(pwd) -w $(pwd) rails-new-$RUBY_VERSION-$RAILS_VERSION rails new $@
-            let status = DockerClient::run_image(&ruby_version, &rails_version, cli.args)
-                .status()
-                .expect("Failed to execute process");
-
-            assert!(status.success());
+            command = DockerClient::run_image(&ruby_version, &rails_version, cli.args)
         }
     }
+
+    let status = command.status().expect("Failed to execute process");
+
+    assert!(status.success());
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,10 +42,9 @@ fn main() {
 
     match &cli.command {
         Some(Commands::RailsHelp {}) => {
-            let mut child = DockerClient::get_help(&ruby_version, &rails_version)
-                .spawn()
+            let status = DockerClient::get_help(&ruby_version, &rails_version)
+                .status()
                 .expect("Failed to execute process");
-            let status = child.wait().expect("failed to wait on child");
 
             assert!(status.success());
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@
 // use std::process::Command;
 mod docker_client;
 mod rails_new;
-use rails_new::Cli;
+use rails_new::{Cli, Commands};
 use std::io::Write;
 
 use clap::Parser;
@@ -40,10 +40,23 @@ fn main() {
 
     assert!(status.success());
 
-    // Run the image with docker run -v $(pwd):/$(pwd) -w $(pwd) rails-new-$RUBY_VERSION-$RAILS_VERSION rails new $@
-    let status = DockerClient::run_image(&ruby_version, &rails_version, cli.args)
-        .status()
-        .expect("Failed to execute process");
+    match &cli.command {
+        Some(Commands::RailsHelp {}) => {
+            let mut child = DockerClient::get_help(&ruby_version, &rails_version)
+                .spawn()
+                .expect("Failed to execute process");
+            let status = child.wait().expect("failed to wait on child");
 
-    assert!(status.success());
+            assert!(status.success());
+        }
+
+        None => {
+            // Run the image with docker run -v $(pwd):/$(pwd) -w $(pwd) rails-new-$RUBY_VERSION-$RAILS_VERSION rails new $@
+            let status = DockerClient::run_image(&ruby_version, &rails_version, cli.args)
+                .status()
+                .expect("Failed to execute process");
+
+            assert!(status.success());
+        }
+    }
 }

--- a/src/rails_new.rs
+++ b/src/rails_new.rs
@@ -44,4 +44,33 @@ mod tests {
 
         Ok(())
     }
+
+    #[test]
+    fn default_values() -> Result<(), Box<dyn std::error::Error>> {
+        use clap::CommandFactory;
+
+        let m = Cli::command().get_matches_from(vec!["rails-new", "my_app"]);
+
+        let ruby_version = m.get_one::<String>("ruby_version").unwrap();
+        let rails_version = m.get_one::<String>("rails_version").unwrap();
+
+        assert_eq!(ruby_version, "3.2.3");
+        assert_eq!(rails_version, "7.1.3");
+
+        Ok(())
+    }
+
+    #[test]
+    fn rails_help() -> Result<(), Box<dyn std::error::Error>> {
+        use clap::CommandFactory;
+
+        let m = Cli::command().get_matches_from(vec!["rails-new", "rails-help"]);
+
+        match m.subcommand_name() {
+            Some("rails-help") => {}
+            _ => panic!("Expected subcommand 'rails-help'"),
+        }
+
+        Ok(())
+    }
 }

--- a/src/rails_new.rs
+++ b/src/rails_new.rs
@@ -1,7 +1,7 @@
-use clap::Parser;
+use clap::{Parser, Subcommand};
 
 #[derive(Parser)]
-#[command(version, about, long_about = None)]
+#[command(version, about, long_about = None, subcommand_negates_reqs = true)]
 pub struct Cli {
     #[clap(trailing_var_arg = true, required = true)]
     /// arguments passed to `rails new`
@@ -10,6 +10,15 @@ pub struct Cli {
     pub ruby_version: String,
     #[clap(long, short = 'r', default_value = "7.1.3")]
     pub rails_version: String,
+
+    #[command(subcommand)]
+    pub command: Option<Commands>,
+}
+
+#[derive(Subcommand)]
+pub enum Commands {
+    /// Prints `rails new --help`
+    RailsHelp {},
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This PR allows to expose `rails new --help` output as a subcommand for `rails-new`

closes #7 


<details>
<summary>

`./target/debug/rails-new help`

</summary>

```
A CLI tool to generate a new Rails project

Usage: rails-new [OPTIONS] <ARGS>...
       rails-new [OPTIONS] [ARGS]... <COMMAND>

Commands:
  rails-help  Prints `rails --help`
  help        Print this message or the help of the given subcommand(s)

Arguments:
  <ARGS>...  arguments passed to `rails new`

Options:
  -u, --ruby-version <RUBY_VERSION>    [default: 3.2.3]
  -r, --rails-version <RAILS_VERSION>  [default: 7.1.3]
  -h, --help                           Print help
  -V, --version                        Print version
```

</details>


<details>
<summary>

`./target/debug/rails-new rails-help`

</summary>

```
Usage:
  rails new APP_PATH [options]

Options:
                 [--skip-namespace]                             # Skip namespace (affects only isolated engines)
                                                                # Default: false
                 [--skip-collision-check]                       # Skip collision check
                                                                # Default: false
  -r,            [--ruby=PATH]                                  # Path to the Ruby binary of your choice
                                                                # Default: /usr/local/bin/ruby
  -n,            [--name=NAME]                                  # Name of the app
  -m,            [--template=TEMPLATE]                          # Path to some application template (can be a filesystem path or URL)
  -d,            [--database=DATABASE]                          # Preconfigure for selected database (options: mysql/trilogy/postgresql/sqlite3/oracle/sqlserver/jdbcmysql/jdbcsqlite3/jdbcpostgresql/jdbc)
                                                                # Default: sqlite3
  -G,            [--skip-git]                                   # Skip git init, .gitignore and .gitattributes
                 [--skip-docker]                                # Skip Dockerfile, .dockerignore and bin/docker-entrypoint
                 [--skip-keeps]                                 # Skip source control .keep files
  -M,            [--skip-action-mailer]                         # Skip Action Mailer files
                 [--skip-action-mailbox]                        # Skip Action Mailbox gem
                 [--skip-action-text]                           # Skip Action Text gem
  -O,            [--skip-active-record]                         # Skip Active Record files
                 [--skip-active-job]                            # Skip Active Job
                 [--skip-active-storage]                        # Skip Active Storage files
  -C,            [--skip-action-cable]                          # Skip Action Cable files
  -A,            [--skip-asset-pipeline]                        # Indicates when to generate skip asset pipeline
  -a,            [--asset-pipeline=ASSET_PIPELINE]              # Choose your asset pipeline [options: sprockets (default), propshaft]
                                                                # Default: sprockets
  -J, --skip-js, [--skip-javascript]                            # Skip JavaScript files
                 [--skip-hotwire]                               # Skip Hotwire integration
                 [--skip-jbuilder]                              # Skip jbuilder gem
  -T,            [--skip-test]                                  # Skip test files
                 [--skip-system-test]                           # Skip system test files
                 [--skip-bootsnap]                              # Skip bootsnap gem
                 [--skip-dev-gems]                              # Skip development gems (e.g., web-console)
                 [--dev], [--no-dev], [--skip-dev]              # Set up the application with Gemfile pointing to your Rails checkout
                 [--edge], [--no-edge], [--skip-edge]           # Set up the application with a Gemfile pointing to the 7-1-stable branch on the Rails repository
  --master,      [--main], [--no-main], [--skip-main]           # Set up the application with Gemfile pointing to Rails repository main branch
                 [--rc=RC]                                      # Path to file containing extra configuration options for rails command
                 [--no-rc]                                      # Skip loading of extra configuration options from .railsrc file
                 [--api], [--no-api], [--skip-api]              # Preconfigure smaller stack for API only apps
                                                                # Default: false
                 [--minimal], [--no-minimal], [--skip-minimal]  # Preconfigure a minimal rails app
  -j, --js,      [--javascript=JAVASCRIPT]                      # Choose JavaScript approach [options: importmap (default), bun, webpack, esbuild, rollup]
                                                                # Default: importmap
  -c,            [--css=CSS]                                    # Choose CSS processor [options: tailwind, bootstrap, bulma, postcss, sass] check https://github.com/rails/cssbundling-rails for more options
  -B,            [--skip-bundle]                                # Don't run bundle install
                 [--skip-decrypted-diffs]                       # Don't configure git to show decrypted diffs of encrypted credentials

Runtime options:
  -f, [--force]                                      # Overwrite files that already exist
  -p, [--pretend], [--no-pretend], [--skip-pretend]  # Run but do not make any changes
  -q, [--quiet], [--no-quiet], [--skip-quiet]        # Suppress status output
  -s, [--skip], [--no-skip], [--skip-skip]           # Skip files that already exist

Rails options:
  -h, [--help], [--no-help], [--skip-help]           # Show this help message and quit
  -v, [--version], [--no-version], [--skip-version]  # Show Rails version number and quit

Description:
    The `rails new` command creates a new Rails application with a default
    directory structure and configuration at the path you specify.

    You can specify extra command-line arguments to be used every time
    `rails new` runs in the .railsrc configuration file in your home directory,
    or in $XDG_CONFIG_HOME/rails/railsrc if XDG_CONFIG_HOME is set.

    Note that the arguments specified in the .railsrc file don't affect the
    default values shown above in this help message.

    You can specify which version to use when creating a new rails application 
    using `rails _<version>_ new`.

Examples:
    `rails new ~/Code/Ruby/weblog`

    This generates a new Rails app in ~/Code/Ruby/weblog.

    `rails _<version>_ new weblog`

    This generates a new Rails app with the provided version in ./weblog.

    `rails new weblog --api`

    This generates a new Rails app in API mode in ./weblog.

    `rails new weblog --skip-action-mailer`

    This generates a new Rails app without Action Mailer in ./weblog.
    Any part of Rails can be skipped during app generation.
```

</details>
