### PR TITLE
Add '-o' to groupadd and useradd to fix error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ ARG RUBY_VERSION=3.2.3
 FROM ruby:${RUBY_VERSION}
 ARG USER_ID=1000
 ARG GROUP_ID=1000
-RUN groupadd -g $GROUP_ID app && useradd -u $USER_ID -g app -m app
+RUN groupadd -g $GROUP_ID app -o && useradd -u $USER_ID -g app -m app -o
 USER app
 ARG RAILS_VERSION
 # Install Rails based on the version specified but if not specified, install the latest version.


### PR DESCRIPTION
- macOS: 14.4.1 Sonoma
- Docker Desktop for Mac: 4.28.0 (139021)
- cargo 1.74.1 (ecb9851af 2023-10-18)

As far as I checked this tool by running`cargo clean;cargo build;cargo install --path .` and then `path/to/rails-new app_name --main`, the following error occurs:

```
 => ERROR [2/3] RUN groupadd -g 20 app && useradd -u 501 -g app -m app                      0.1s
------
 > [2/3] RUN groupadd -g 20 app && useradd -u 501 -g app -m app:
0.132 groupadd: GID '20' already exists
------
Dockerfile:5
--------------------
   3 |     ARG USER_ID=1000
   4 |     ARG GROUP_ID=1000
   5 | >>> RUN groupadd -g $GROUP_ID app && useradd -u $USER_ID -g app -m app
   6 |     USER app
   7 |     ARG RAILS_VERSION
--------------------
ERROR: failed to solve: process "/bin/sh -c groupadd -g $GROUP_ID app && useradd -u $USER_ID -g app -m app" did not complete successfully: exit code: 4

View build details: docker-desktop://dashboard/build/desktop-linux/desktop-linux/ise7q36c2kuyza1pnuw26km5y
thread 'main' panicked at src/main.rs:41:5:
assertion failed: status.success()
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

I added `-o` options to groupadd and useradd to fix the error.