### PR TITLE
[proposal] Add node and yarn installation logic to dockerfile, bump ruby to 3.3.6, bump rails to 8.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,18 @@
 ARG RUBY_VERSION=3.4.1
 FROM ruby:${RUBY_VERSION}
+
+ARG NODE_VERSION=v22.6.0
+ARG YARN_VERSION=1.22.22
+
+RUN curl -fsSL https://nodejs.org/dist/$NODE_VERSION/node-$NODE_VERSION-linux-x64.tar.gz \
+      -o /tmp/node-$NODE_VERSION-linux-x64.tar.gz \
+  && tar -xzvf /tmp/node-$NODE_VERSION-linux-x64.tar.gz -C /usr/local \
+  && rm -rf /tmp/node-$NODE_VERSION-linux-x64.tar.gz
+
+ENV PATH=/usr/local/node-$NODE_VERSION-linux-x64/bin:$PATH
+
+RUN npm install -g yarn@$YARN_VERSION
+
 ARG RAILS_VERSION
 # Install Rails based on the version specified but if not specified, install the latest version.
 RUN if [ -z "$RAILS_VERSION" ] ; then gem install rails ; else gem install rails -v $RAILS_VERSION ; fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,13 @@
 ARG RUBY_VERSION=3.4.1
 FROM ruby:${RUBY_VERSION}
 
-ARG NODE_VERSION=v22.6.0
+ARG NODE_VERSION=22
 ARG YARN_VERSION=1.22.22
 
-RUN curl -fsSL https://nodejs.org/dist/$NODE_VERSION/node-$NODE_VERSION-linux-x64.tar.gz \
-      -o /tmp/node-$NODE_VERSION-linux-x64.tar.gz \
-  && tar -xzvf /tmp/node-$NODE_VERSION-linux-x64.tar.gz -C /usr/local \
-  && rm -rf /tmp/node-$NODE_VERSION-linux-x64.tar.gz
-
-ENV PATH=/usr/local/node-$NODE_VERSION-linux-x64/bin:$PATH
-
-RUN npm install -g yarn@$YARN_VERSION
+RUN curl -sL https://deb.nodesource.com/setup_$NODE_VERSION.x | bash - \
+  && apt-get update \
+  && apt-get install --yes --no-install-recommends nodejs \
+  && npm install -g yarn@$YARN_VERSION
 
 ARG RAILS_VERSION
 # Install Rails based on the version specified but if not specified, install the latest version.

--- a/Dockerfile.unix
+++ b/Dockerfile.unix
@@ -1,10 +1,25 @@
 ARG RUBY_VERSION=3.4.1
 FROM ruby:${RUBY_VERSION}
+
 ARG USER_ID=1000
 ARG GROUP_ID=1000
 RUN (getent group $GROUP_ID > /dev/null || groupadd -g $GROUP_ID app) && \
     (getent passwd $USER_ID > /dev/null || useradd -u $USER_ID -g $GROUP_ID -m app)
+
+ARG NODE_VERSION=v22.6.0
+ARG YARN_VERSION=1.22.22
+
+RUN curl -fsSL https://nodejs.org/dist/$NODE_VERSION/node-$NODE_VERSION-linux-x64.tar.gz \
+      -o /tmp/node-$NODE_VERSION-linux-x64.tar.gz \
+  && tar -xzvf /tmp/node-$NODE_VERSION-linux-x64.tar.gz -C /usr/local \
+  && rm -rf /tmp/node-$NODE_VERSION-linux-x64.tar.gz
+
+ENV PATH=/usr/local/node-$NODE_VERSION-linux-x64/bin:$PATH
+
+RUN npm install -g yarn@$YARN_VERSION
+
 USER $USER_ID:$GROUP_ID
+
 ARG RAILS_VERSION
 # Install Rails based on the version specified but if not specified, install the latest version.
 RUN if [ -z "$RAILS_VERSION" ] ; then gem install rails ; else gem install rails -v $RAILS_VERSION ; fi

--- a/Dockerfile.unix
+++ b/Dockerfile.unix
@@ -6,17 +6,13 @@ ARG GROUP_ID=1000
 RUN (getent group $GROUP_ID > /dev/null || groupadd -g $GROUP_ID app) && \
     (getent passwd $USER_ID > /dev/null || useradd -u $USER_ID -g $GROUP_ID -m app)
 
-ARG NODE_VERSION=v22.6.0
+ARG NODE_VERSION=22
 ARG YARN_VERSION=1.22.22
 
-RUN curl -fsSL https://nodejs.org/dist/$NODE_VERSION/node-$NODE_VERSION-linux-x64.tar.gz \
-      -o /tmp/node-$NODE_VERSION-linux-x64.tar.gz \
-  && tar -xzvf /tmp/node-$NODE_VERSION-linux-x64.tar.gz -C /usr/local \
-  && rm -rf /tmp/node-$NODE_VERSION-linux-x64.tar.gz
-
-ENV PATH=/usr/local/node-$NODE_VERSION-linux-x64/bin:$PATH
-
-RUN npm install -g yarn@$YARN_VERSION
+RUN curl -sL https://deb.nodesource.com/setup_$NODE_VERSION.x | bash - \
+  && apt-get update \
+  && apt-get install --yes --no-install-recommends nodejs \
+  && npm install -g yarn@$YARN_VERSION
 
 USER $USER_ID:$GROUP_ID
 

--- a/src/rails_new.rs
+++ b/src/rails_new.rs
@@ -17,7 +17,7 @@ pub struct Cli {
 
 #[derive(Subcommand)]
 pub enum Commands {
-    /// Prints `rails new --help`
+    /// Print `rails new --help`
     RailsHelp {},
 }
 


### PR DESCRIPTION
This PR addresses issue #22 

Currently our `Dockerfile` image doesn't have `node` and `yarn` binaries which results in errors when using `--js` or `--css` switches. 

This PR adds logic for downloading `node 22.7.0` binary and installing `yarn 1.22.22` to our dockerfiles. It also bumps default `ruby` to `3.3.5` and default `rails` to `7.2.1`

### How this was tested?

```
> cargo build
```

```
> ./target/debug/rails-new main --js esbuild --css tailwind

>  docker run -it --rm -v $(pwd)/main:/rails -w /rails -p 3000:3000 -e BINDING=0.0.0.0 rails-new-3.3.5-7.2.1 /bin/bash -c "bundle install && ./bin/dev"

> visited http://localhost:3000 and confirmed that page is live

> docker run -it --rm rails-new-3.3.5-7.2.1 bash

root@ac7b091459cb:/# ruby --version
ruby 3.3.5 (2024-09-03 revision ef084cc8f4) [x86_64-linux]
root@ac7b091459cb:/# rails --version
Rails 7.2.1
root@ac7b091459cb:/#  node --version
v22.7.0
root@ac7b091459cb:/#  yarn --version
1.22.22
```

@rafaelfranca, @excid3 let me know what do you think, I'm open to rewritting this PR to your prefered approach

Fixes #22 
Fixes #31 
