### PR TITLE
Fix collisions with existing user and group ids

### DIFF
--- a/Dockerfile.unix
+++ b/Dockerfile.unix
@@ -2,8 +2,9 @@ ARG RUBY_VERSION=3.3.4
 FROM ruby:${RUBY_VERSION}
 ARG USER_ID=1000
 ARG GROUP_ID=1000
-RUN groupadd -g $GROUP_ID app && useradd -u $USER_ID -g app -m app
-USER app
+RUN (getent group $GROUP_ID > /dev/null || groupadd -g $GROUP_ID app) && \
+    (getent passwd $USER_ID > /dev/null || useradd -u $USER_ID -g $GROUP_ID -m app)
+USER $USER_ID:$GROUP_ID
 ARG RAILS_VERSION
 # Install Rails based on the version specified but if not specified, install the latest version.
 RUN if [ -z "$RAILS_VERSION" ] ; then gem install rails ; else gem install rails -v $RAILS_VERSION ; fi


### PR DESCRIPTION
Do not add groups or users if ther gid or uid already exists in the base image. We also make useradd and the USER instruction depend on numeric ids since we can't guarantee that a group or user with name `app` exists.
The USER instruction now also includes the group id to ensure that any created files have the expected user and group ownership.