### PR TITLE
Make Rails arguments optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+.idea

--- a/src/rails_new.rs
+++ b/src/rails_new.rs
@@ -3,7 +3,7 @@ use clap::{Parser, Subcommand};
 #[derive(Parser)]
 #[command(version, about, long_about = None, subcommand_negates_reqs = true)]
 pub struct Cli {
-    #[clap(trailing_var_arg = true, required = true)]
+    #[clap(trailing_var_arg = true)]
     /// arguments passed to `rails new`
     pub args: Vec<String>,
     #[clap(long, short = 'u', default_value = "latest")]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,17 +1,15 @@
 use assert_cmd::prelude::*;
-use predicates::prelude::*;
 use std::process::Command;
 
 #[test]
 fn requires_a_name() -> Result<(), Box<dyn std::error::Error>> {
-    let mut cmd = Command::cargo_bin("rails-new")?;
+  let mut cmd = Command::cargo_bin("rails-new")?;
 
-    cmd.assert()
-        .failure()
-        .stderr(predicate::str::contains(
-            "the following required arguments were not provided:",
-        ))
-        .stderr(predicate::str::contains("<ARGS>..."));
+  cmd
+    .spawn()
+    .unwrap()
+    .wait_with_output()
+    .expect("rails new weblog --api");
 
-    Ok(())
+  Ok(())
 }


### PR DESCRIPTION
### Motivation:
Calling rails-new without any arguments fails with error: (error: the following required arguments were not provided: <ARGS>..). Making rails arguments optional allows to simply run `rails-new` and see what params are required for scaffolding new rails application (for example app name).

### Original and updated behaviour

#### Without any parameters

Original 
```sh
rails-new

error: the following required arguments were not provided:
  <ARGS>...

Usage: rails-new <ARGS>...

For more information, try '--help'.
```

Updated
```sh
rails-new

Starts the docker container and shows the normal ruby on rails generator text:

Usage:                                                                                                                                         
  rails new APP_PATH [options]                                                                                                                 

Options:
  [--skip-namespace]. # Skip namespace (affects only isolated engines)
...
```
