### PR TITLE
Enable syntax highlighting on Dockerfile.* files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+Dockerfile.* linguist-language=Dockerfile


### PR DESCRIPTION
This PR enables syntax highlighting on non-standard Dockefiles on GitHub, although `Dockefile.unix` is now the only one.

Here's an example of `Dockefile.unix`:

| Before | After |
|--------|--------|
| <img width="556" alt="image" src="https://github.com/user-attachments/assets/dc9a02db-b716-4b3f-ab8a-01dd2bba026d"> | <img width="544" alt="image" src="https://github.com/user-attachments/assets/ffa51090-c1f2-43ef-926a-948d6c4d85a0"> |

Ref https://github.com/github-linguist/linguist/blob/f164d13fa618023ecf2d8f2ed9a6ce5fae731346/docs/overrides.md