### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Rails versions for you, so you don't have to worry about it.
 You need to have Docker installed on your machine. You can find instructions on how to install Docker on your machine
 [here](https://docs.docker.com/engine/install/).
 
+**On Linux**, your user needs to be a member of the docker group. rails-new does not work with sudo. You can find instructions on this [here](https://docs.docker.com/engine/install/linux-postinstall/)
+
 ## Installation
 
 Go to the [latest release](https://github.com/rails/rails-new/releases/latest) and download the executable for your platform (not the source code). For example, on M1 macOS this would be `rails-new-aarch64-apple-darwin.tar.gz`. Once the download is complete, unzip the `.tar.gz` file, which will create the `rails-new` executable. Move the executable into your path so that it is ready to run from the command line.


### PR DESCRIPTION
Running rails-new with sudo causes the following error during the initial 

Step 5/8 : RUN groupadd -g $GROUP_ID app && useradd -u $USER_ID -g app -m app
 ---> Running in 283cd70fd9e4
groupadd: GID '0' already exists
The command '/bin/sh -c groupadd -g $GROUP_ID app && useradd -u $USER_ID -g app -m app' returned a non-zero code: 4 thread 'main' panicked at src/main.rs:41:5:
assertion failed: status.success()