### PR TITLE
Remove hardcoded Ruby/Rails versions, add `--rebuild` flag

### DIFF
--- a/src/docker_client.rs
+++ b/src/docker_client.rs
@@ -207,6 +207,72 @@ mod tests {
     }
 
     #[test]
+    fn build_image_with_rebuild_flag() {
+        let command = DockerClient::build_image("3.2.3", Some("7.1.3"), None, None, true);
+
+        let args: Vec<&OsStr> = command.get_args().collect();
+
+        assert_eq!(
+            args,
+            &[
+                "build",
+                "--no-cache",
+                "--build-arg",
+                "RUBY_VERSION=3.2.3",
+                "--build-arg",
+                "RAILS_VERSION=7.1.3",
+                "-t",
+                "rails-new-3.2.3-7.1.3",
+                "-",
+            ]
+        );
+    }
+
+    #[test]
+    fn build_image_without_rails_version() {
+        let command = DockerClient::build_image("3.2.3", None, None, None, false);
+
+        let args: Vec<&OsStr> = command.get_args().collect();
+
+        assert_eq!(
+            args,
+            &[
+                "build",
+                "--build-arg",
+                "RUBY_VERSION=3.2.3",
+                "-t",
+                "rails-new-3.2.3",
+                "-",
+            ]
+        );
+    }
+
+    #[test]
+    fn build_image_with_both_ids() {
+        let command = DockerClient::build_image("3.2.3", Some("7.1.3"), Some(1000), Some(1000), false);
+
+        let args: Vec<&OsStr> = command.get_args().collect();
+
+        assert_eq!(
+            args,
+            &[
+                "build",
+                "--build-arg",
+                "RUBY_VERSION=3.2.3",
+                "--build-arg",
+                "RAILS_VERSION=7.1.3",
+                "--build-arg",
+                "USER_ID=1000",
+                "--build-arg",
+                "GROUP_ID=1000",
+                "-t",
+                "rails-new-3.2.3-7.1.3",
+                "-",
+            ]
+        );
+    }
+
+    #[test]
     fn run_image() {
         let command = DockerClient::run_image("3.2.3", Some("7.1.3"), vec!["my_app".to_string()]);
 
@@ -228,6 +294,33 @@ mod tests {
                 "-w",
                 current_dir,
                 "rails-new-3.2.3-7.1.3",
+                "rails",
+                "new",
+                "my_app",
+            ]
+        );
+    }
+
+    #[test]
+    fn run_image_without_rails_version() {
+        let command = DockerClient::run_image("3.2.3", None, vec!["my_app".to_string()]);
+
+        let binding = current_dir().unwrap();
+        let absolute_path = canonicalize_os_path(&binding).unwrap();
+        let current_dir = absolute_path.to_str().unwrap();
+
+        let args: Vec<&OsStr> = command.get_args().collect();
+
+        assert_eq!(
+            args,
+            &[
+                "run",
+                "--rm",
+                "-v",
+                &format!("{}:{}", current_dir, current_dir),
+                "-w",
+                current_dir,
+                "rails-new-3.2.3",
                 "rails",
                 "new",
                 "my_app",

--- a/src/docker_client.rs
+++ b/src/docker_client.rs
@@ -8,10 +8,15 @@ impl DockerClient {
         rails_version: &str,
         user_id: Option<u32>,
         group_id: Option<u32>,
+        rebuild: bool,
     ) -> Command {
         let mut command = Command::new("docker");
 
         command.arg("build");
+
+        if rebuild {
+            command.arg("--no-cache");
+        }
 
         Self::set_build_arg(&mut command, "RUBY_VERSION", ruby_version);
         Self::set_build_arg(&mut command, "RAILS_VERSION", rails_version);
@@ -116,7 +121,7 @@ mod tests {
 
     #[test]
     fn build_image() {
-        let command = DockerClient::build_image("3.2.3", "7.1.3", None, None);
+        let command = DockerClient::build_image("3.2.3", "7.1.3", None, None, false);
 
         assert_eq!(command.get_program(), "docker");
 
@@ -139,7 +144,7 @@ mod tests {
 
     #[test]
     fn build_image_with_user_id() {
-        let command = DockerClient::build_image("3.2.3", "7.1.3", Some(1000), None);
+        let command = DockerClient::build_image("3.2.3", "7.1.3", Some(1000), None, false);
 
         assert_eq!(command.get_program(), "docker");
 
@@ -164,7 +169,7 @@ mod tests {
 
     #[test]
     fn build_image_with_group_id() {
-        let command = DockerClient::build_image("3.2.3", "7.1.3", None, Some(1000));
+        let command = DockerClient::build_image("3.2.3", "7.1.3", None, Some(1000), false);
 
         assert_eq!(command.get_program(), "docker");
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,14 +18,14 @@ fn main() {
     let cli = Cli::parse();
 
     let ruby_version = cli.ruby_version;
-    let rails_version = cli.rails_version;
+    let rails_version = cli.rails_version.as_deref();
     let rebuild = cli.rebuild;
 
     // Run docker build --build-arg RUBY_VERSION=$RUBY_VERSION --build-arg RAILS_VERSION=$RAILS_VERSION -t rails-new-$RUBY_VERSION-$RAILS_VERSION
     // passing the content of DOCKERFILE to the command stdin
     let mut child = DockerClient::build_image(
         &ruby_version,
-        &rails_version,
+        rails_version,
         os_specific::get_user_id(),
         os_specific::get_group_id(),
         rebuild,
@@ -46,12 +46,12 @@ fn main() {
 
     match &cli.command {
         Some(Commands::RailsHelp {}) => {
-            command = DockerClient::get_help(&ruby_version, &rails_version)
+            command = DockerClient::get_help(&ruby_version, rails_version)
         }
 
         None => {
             // Run the image with docker run -v $(pwd):/$(pwd) -w $(pwd) rails-new-$RUBY_VERSION-$RAILS_VERSION rails new $@
-            command = DockerClient::run_image(&ruby_version, &rails_version, cli.args)
+            command = DockerClient::run_image(&ruby_version, rails_version, cli.args)
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,7 @@ fn main() {
 
     let ruby_version = cli.ruby_version;
     let rails_version = cli.rails_version;
+    let rebuild = cli.rebuild;
 
     // Run docker build --build-arg RUBY_VERSION=$RUBY_VERSION --build-arg RAILS_VERSION=$RAILS_VERSION -t rails-new-$RUBY_VERSION-$RAILS_VERSION
     // passing the content of DOCKERFILE to the command stdin
@@ -27,6 +28,7 @@ fn main() {
         &rails_version,
         os_specific::get_user_id(),
         os_specific::get_group_id(),
+        rebuild,
     )
     .spawn()
     .expect("Failed to execute process");

--- a/src/rails_new.rs
+++ b/src/rails_new.rs
@@ -10,6 +10,8 @@ pub struct Cli {
     pub ruby_version: String,
     #[clap(long, short = 'r', default_value = "8.0.1")]
     pub rails_version: String,
+    #[clap(long)]
+    pub rebuild: bool,
 
     #[command(subcommand)]
     pub command: Option<Commands>,

--- a/src/rails_new.rs
+++ b/src/rails_new.rs
@@ -8,8 +8,8 @@ pub struct Cli {
     pub args: Vec<String>,
     #[clap(long, short = 'u', default_value = "3.4.1")]
     pub ruby_version: String,
-    #[clap(long, short = 'r', default_value = "8.0.1")]
-    pub rails_version: String,
+    #[clap(long, short = 'r')]
+    pub rails_version: Option<String>,
     #[clap(long)]
     pub rebuild: bool,
 
@@ -54,10 +54,8 @@ mod tests {
         let m = Cli::command().get_matches_from(vec!["rails-new", "my_app"]);
 
         let ruby_version = m.get_one::<String>("ruby_version").unwrap();
-        let rails_version = m.get_one::<String>("rails_version").unwrap();
 
         assert_eq!(ruby_version, "3.4.1");
-        assert_eq!(rails_version, "8.0.1");
 
         Ok(())
     }

--- a/src/rails_new.rs
+++ b/src/rails_new.rs
@@ -6,7 +6,7 @@ pub struct Cli {
     #[clap(trailing_var_arg = true, required = true)]
     /// arguments passed to `rails new`
     pub args: Vec<String>,
-    #[clap(long, short = 'u', default_value = "3.4.1")]
+    #[clap(long, short = 'u', default_value = "latest")]
     pub ruby_version: String,
     #[clap(long, short = 'r')]
     pub rails_version: Option<String>,
@@ -55,7 +55,7 @@ mod tests {
 
         let ruby_version = m.get_one::<String>("ruby_version").unwrap();
 
-        assert_eq!(ruby_version, "3.4.1");
+        assert_eq!(ruby_version, "latest");
 
         Ok(())
     }

--- a/src/rails_new.rs
+++ b/src/rails_new.rs
@@ -73,4 +73,52 @@ mod tests {
 
         Ok(())
     }
+
+    #[test]
+    fn custom_ruby_version() -> Result<(), Box<dyn std::error::Error>> {
+        use clap::CommandFactory;
+
+        let m = Cli::command().get_matches_from(vec!["rails-new", "--ruby-version", "3.2.0", "my_app"]);
+        let ruby_version = m.get_one::<String>("ruby_version").unwrap();
+        assert_eq!(ruby_version, "3.2.0");
+
+        // Test short form
+        let m = Cli::command().get_matches_from(vec!["rails-new", "-u", "3.2.0", "my_app"]);
+        let ruby_version = m.get_one::<String>("ruby_version").unwrap();
+        assert_eq!(ruby_version, "3.2.0");
+
+        Ok(())
+    }
+
+    #[test]
+    fn rails_version_flag() -> Result<(), Box<dyn std::error::Error>> {
+        use clap::CommandFactory;
+
+        let m = Cli::command().get_matches_from(vec!["rails-new", "--rails-version", "7.1.0", "my_app"]);
+        let rails_version = m.get_one::<String>("rails_version").unwrap();
+        assert_eq!(rails_version, "7.1.0");
+
+        // Test short form
+        let m = Cli::command().get_matches_from(vec!["rails-new", "-r", "7.1.0", "my_app"]);
+        let rails_version = m.get_one::<String>("rails_version").unwrap();
+        assert_eq!(rails_version, "7.1.0");
+
+        Ok(())
+    }
+
+    #[test]
+    fn rebuild_flag() -> Result<(), Box<dyn std::error::Error>> {
+        use clap::CommandFactory;
+
+        let m = Cli::command().get_matches_from(vec!["rails-new", "--rebuild", "my_app"]);
+        let rebuild = m.get_flag("rebuild");
+        assert!(rebuild);
+
+        // Test default value (false)
+        let m = Cli::command().get_matches_from(vec!["rails-new", "my_app"]);
+        let rebuild = m.get_flag("rebuild");
+        assert!(!rebuild);
+
+        Ok(())
+    }
 }


### PR DESCRIPTION
[Add --rebuild flag to force rebuilding the image](https://github.com/rails/rails-new/commit/68a2913627bb6fca445ab13b876dcc96e95bcbc5)

Currently, `rails-new` must be released to use any newly released
versions of Ruby/Rails by default. To address this, I'd like to remove
the fallback versions of Ruby/Rails in the CLI arguments. However, this
will mean that the image name no longer contains the Rails version, and
that can lead to a stale Rails version when running `rails-new` if it
has been previously built.

This commit addresses that by providing a `--rebuild` option which
forces the container to be rebuilt and ensures the latest version of
Rails is installed and used.

---

[Remove default Rails version](https://github.com/rails/rails-new/commit/89e44af855b1bcf16dfffacc42b52f91f734a035)

This enables `gem install rails` in the Dockerfile to always install the
latest Rails version instead of the default value in `rails-new`.

---

[Replace default Ruby version with "latest"](https://github.com/rails/rails-new/commit/1f07fca028c46b0462f42aa1cd3d9e7418f22358)

This will prevent having to update and release a new version of
`rails-new` when new versions of Ruby are released.